### PR TITLE
Add check for if `OPENED_POPUPS[key]` is undefined

### DIFF
--- a/content_scripts/dictionary-plus.js
+++ b/content_scripts/dictionary-plus.js
@@ -671,5 +671,3 @@ function onStorageChange(changes, area) {
 }
 
 browser.storage.onChanged.addListener(onStorageChange);
-
-

--- a/content_scripts/dictionary-plus.js
+++ b/content_scripts/dictionary-plus.js
@@ -670,5 +670,6 @@ function onStorageChange(changes, area) {
   SETTINGS = settings.newValue;
 }
 
-
 browser.storage.onChanged.addListener(onStorageChange);
+
+

--- a/content_scripts/dictionary-plus.js
+++ b/content_scripts/dictionary-plus.js
@@ -543,7 +543,10 @@ function saveWord(key) {
 
 
 function updatePopUp(key, data) {
-  const popupNode = OPENED_POPUPS[key].node;
+  const popupNode = OPENED_POPUPS[key]?.node;
+
+  // If user clicks out before definition is retrieved, `OPEN_POPUPS[key]` will not exist
+  if (popupNode === undefined) return;
 
   const popup = popupNode.shadowRoot;
 
@@ -666,5 +669,6 @@ function onStorageChange(changes, area) {
   // update settings
   SETTINGS = settings.newValue;
 }
+
 
 browser.storage.onChanged.addListener(onStorageChange);


### PR DESCRIPTION
Prevents the following error:
```none
TypeError: can't access property "node", OPENED_POPUPS[key] is undefined
```
It appears when the user clicks off the popup before the definition is retrieved, spamming the console logs with the error.